### PR TITLE
Increase default points to 6k

### DIFF
--- a/frontend/src/app/chart/chart.component.ts
+++ b/frontend/src/app/chart/chart.component.ts
@@ -53,7 +53,7 @@ export class ChartComponent implements OnInit, OnDestroy {
   frequency_ratio: string;
   strategyType = STRATEGY;
   subscription: Subscription;
-  number = new FormControl(600);
+  number = new FormControl(6000);
   inactiveChannels = [];
   startTime = 0;
   endTime = 0;


### PR DESCRIPTION
At 600 points, the chart is still a bit too rough for us to tell when spikes start and end for anything longer than 5 minutes.
